### PR TITLE
ニュース：バナー告知調整

### DIFF
--- a/_posts/2016-06-20-started-to-provide-banner.md
+++ b/_posts/2016-06-20-started-to-provide-banner.md
@@ -17,21 +17,21 @@ DojoCon Japan 2016のバナーをご用意しました。ブログやサイト�
 ```
 
 ### 250 x 250
-![250 x 250]({{ '/assets/images/banner-250-250.jpg' | prepend: site.baseurl | prepend: site.url }})
+![250 x 250]({{ '/assets/images/banner-250-250.jpg' | prepend: site.baseurl}})
 
 ```html
 <a href="{{ '/' | prepend: site.baseurl | prepend: site.url }}"><img src="{{ '/assets/images/banner-250-250.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="DojoCon Japan 2016"></a>
 ```
 
 ### 468 x 60
-![468 x 60]({{ '/assets/images/banner-468-60.jpg' | prepend: site.baseurl | prepend: site.url }})
+![468 x 60]({{ '/assets/images/banner-468-60.jpg' | prepend: site.baseurl}})
 
 ```html
 <a href="{{ '/' | prepend: site.baseurl | prepend: site.url }}"><img src="{{ '/assets/images/banner-468-60.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="DojoCon Japan 2016"></a>
 ```
 
 ## プレス用アイキャッチ
-![プレス用アイキャッチ]({{ '/assets/images/eyecatch.jpg' | prepend: site.baseurl | prepend: site.url }})
+![プレス用アイキャッチ]({{ '/assets/images/eyecatch.jpg' | prepend: site.baseurl}})
 
 ```html
 <a href="{{ '/' | prepend: site.baseurl | prepend: site.url }}"><img src="{{ '/assets/images/eyecatch.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="DojoCon Japan 2016"></a>


### PR DESCRIPTION
バナー画像については、baseurlのみprependするように変更
（httpからアクセスされた場合に画像が非表示になるため）
